### PR TITLE
fix: remove fields not specified in docs

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -87,7 +87,6 @@ module.exports = {
                       id
                       title
                       slug
-                      description
                       createdOn
                       featuredImage
                       author {

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -17,7 +17,6 @@ exports.createPages = async ({ graphql, actions, reporter }) => {
               id
               title
               slug
-              description
               createdOn
               featuredImage
               author {

--- a/src/components/bio.js
+++ b/src/components/bio.js
@@ -16,8 +16,6 @@ const Bio = () => {
           data {
             name
             picture
-            description
-            twitterHandle
           }
         }
       }
@@ -32,10 +30,6 @@ const Bio = () => {
       {author?.name && (
         <p>
           Written by <strong>{author.name}</strong> {author?.description || null}
-          {` `}
-          <a href={`https://twitter.com/${author.twitterHandle || ``}`}>
-            You should follow them on Twitter
-          </a>
         </p>
       )}
     </div>

--- a/src/components/seo.js
+++ b/src/components/seo.js
@@ -10,8 +10,8 @@ import PropTypes from "prop-types"
 import { Helmet } from "react-helmet"
 import { useStaticQuery, graphql } from "gatsby"
 
-const Seo = ({ description, lang, meta, title }) => {
-  const { site, webiny } = useStaticQuery(
+const Seo = ({ lang, meta, title }) => {
+  const { site } = useStaticQuery(
     graphql`
       query {
         site {
@@ -25,8 +25,6 @@ const Seo = ({ description, lang, meta, title }) => {
             data {
               name
               picture
-              description
-              twitterHandle
             }
           }
         }
@@ -34,7 +32,7 @@ const Seo = ({ description, lang, meta, title }) => {
     `
   )
 
-  const metaDescription = description || site.siteMetadata.description
+  const metaDescription = site.siteMetadata.description
   const defaultTitle = site.siteMetadata?.title
 
   return (
@@ -64,10 +62,6 @@ const Seo = ({ description, lang, meta, title }) => {
         {
           name: `twitter:card`,
           content: `summary`,
-        },
-        {
-          name: `twitter:creator`,
-          content: webiny.getAuthor.data.twitterHandle || ``,
         },
         {
           name: `twitter:title`,

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -8,7 +8,7 @@ import Seo from "../components/seo"
 
 const BlogIndex = ({ data, location }) => {
   const siteTitle = data.site.siteMetadata?.title || `Title`
-  
+
   const posts = data.webiny.listPosts.data
 
   if (posts.length === 0) {
@@ -47,9 +47,6 @@ const BlogIndex = ({ data, location }) => {
                   </h2>
                   <DateFormatter dateString={post.createdOn}/>
                 </header>
-                <section>
-                  <p>{post.description}</p>
-                </section>
               </article>
             </li>
           )
@@ -74,7 +71,6 @@ export const pageQuery = graphql`
           id
           title
           slug
-          description
           createdOn
           featuredImage
           author {

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -14,7 +14,6 @@ const BlogPostTemplate = ({ data, location }) => {
     <Layout location={location} title={siteTitle}>
       <Seo
         title={post.title}
-        description={post.description || post.excerpt}
       />
       <article
         className="blog-post"
@@ -84,7 +83,6 @@ export const pageQuery = graphql`
           id
           title
           slug
-          description
           createdOn
           featuredImage
           body
@@ -106,6 +104,6 @@ export const pageQuery = graphql`
           slug
         }
       }
-    } 
+    }
   }
 `


### PR DESCRIPTION
Currently, this template references a few fields not specified in the README or the website docs (https://www.webiny.com/docs/headless-cms/integrations/gatsby). 

<img width="906" alt="Screen Shot 2022-05-08 at 17 08 49" src="https://user-images.githubusercontent.com/630449/167319646-2c83d481-bd3a-4e32-abb7-c78a49973cf5.png">

<img width="960" alt="Screen Shot 2022-05-08 at 17 09 11" src="https://user-images.githubusercontent.com/630449/167319649-b2730cc4-8c4b-46b3-b4a7-af4f34f1c555.png">


Author is missing:
- description
- twitterHandle

Post is missing:
- description

This causes errors to be thrown when following the instructions.

Alternatively, if you don't want to remove these fields from the template, the readme and website should be updated to include those fields.